### PR TITLE
Disable Twig cache

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -2,3 +2,4 @@ twig:
     paths: ['%kernel.project_dir%/templates']
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
+    cache: false # this prevents Twig from attempting to write into the read-only cache directory


### PR DESCRIPTION
Disabling the Twig cache prevents Twig from trying to write into the read-only cache directory while preserving the pre-compiled config cache.